### PR TITLE
Silence magit 1.4 upgrade warning.

### DIFF
--- a/init.el
+++ b/init.el
@@ -171,7 +171,9 @@
   :config (setq ls-lisp-use-insert-directory-program nil))
 
 (use-package magit
-  :diminish magit-auto-revert-mode)
+  :diminish magit-auto-revert-mode
+  :config
+  (setq magit-last-seen-setup-instructions "1.4.0"))
 
 (use-package mardown-mode
   :mode (("\\.md$" . markdown-mode)))


### PR DESCRIPTION
@adam
When you next upgrade packages, it will pull in magit 1.4
This causes a warning to shown in the *Warnings* buffer when you start emacs.

The message in this warning should be read (@mattss and I have discussed this before, and we previously agreed that it wasn't an issue) - however this may be contrary to your expectations, or might just not like it (hence the PR for this instead of me just pushing the change to master).

This PR keeps existing behaviour and just silences the warning. 