### PR TITLE
Diminish netsight mode.

### DIFF
--- a/init.el
+++ b/init.el
@@ -25,6 +25,7 @@
 
 (use-package netsight
   :load-path "lisp"
+  :diminish netsight-mode
   :config
   (progn
     (declare-function global-netsight-mode netsight nil)


### PR DESCRIPTION
This hides the netsight minor-mode indicator from the mode-line, feeing up space.
The globalized netsight minor mode is still active, just not shown.
