### PR TITLE
Open JAQ references in the browser with ffap.

### DIFF
--- a/init.el
+++ b/init.el
@@ -24,7 +24,15 @@
 (use-package netsight
   :load-path "lisp"
   :diminish netsight-mode
+  :preface
+  (defun netsight-ffap ()
+    "Find file at point support for JAQ URLs."
+    (interactive)
+    (let* ((word (thing-at-point 'word))
+	   (url (s-replace "JAQ" netsight-jaq-url word)))
+      (ffap url)))
   :config
+  (bind-key "C-x C-o" #'netsight-ffap netsight-keymap)
   (add-hook 'after-init-hook #'netsight-mode)
   ;; Turn off UI clutter
   (mapc #'apply `((menu-bar-mode -1) (tool-bar-mode -1) (scroll-bar-mode -1)))

--- a/lisp/netsight.el
+++ b/lisp/netsight.el
@@ -37,6 +37,9 @@
   :group 'netsight-modes
   :prefix "netsight:key-")
 
+(defvar netsight-jaq-url "https://jaq.netsight.co.uk/jaq/queue/"
+  "Base URL for the Netsight Task tool.")
+
 (defvar netsight-keymap
   (let ((map (make-sparse-keymap)))
     ;; Keys for custom netsight defuns
@@ -54,7 +57,6 @@
     (define-key map (kbd "M-g f") 'list-faces-display)
     (define-key map (kbd "M-s x") 'replace-regexp)
     (define-key map (kbd "M-z") 'goto-char)
-    (define-key map (kbd "C-x C-o") 'ffap)
     (define-key map (kbd "C-x r r") 'revert-buffer)
     (define-key map (kbd "C-x w") 'woman)
 


### PR DESCRIPTION
Default key binding is set to `C-x C-o`.

Overriding this in your `.emacs-custom.el`:

```lisp
;; example overriding key to be C-c C-j'
(use-package netsight
    :config
    (bind-key "C-c C-j" #'netsight-ffap netsight-keymap))
``` 
